### PR TITLE
work-around for a timing issue

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -24,8 +24,6 @@
 
 #endif
 
-
-
 /****************************************
  * CUDA related code
  *****************************************/
@@ -558,6 +556,7 @@ nixl_status_t nixlUcxEngine::registerMem (const nixlBlobDesc &mem,
                                           const nixl_mem_t &nixl_mem,
                                           nixlBackendMD* &out)
 {
+    printf("nixlUcxEngine::registerMem called\n");
     int ret;
     nixlUcxPrivateMetadata *priv = new nixlUcxPrivateMetadata;
     uint64_t rkey_addr;


### PR DESCRIPTION
There is a timing issue in nixl that can be temporarily resolved using a printf statement. The root cause has yet to be determined